### PR TITLE
fix: respect PWPUSH_ENDPOINT env var in provider config and handle 422 response code

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -19,8 +19,7 @@ func Provider() *schema.Provider {
 			"endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "https://pwpush.com",
-				DefaultFunc: schema.EnvDefaultFunc("PWPUSH_ENDPOINT", nil),
+				DefaultFunc: schema.EnvDefaultFunc("PWPUSH_ENDPOINT", "https://pwpush.com"),
 				Description: "Base URL of the Password Pusher service.",
 			},
 			"email": {

--- a/internal/resource_push.go
+++ b/internal/resource_push.go
@@ -208,7 +208,6 @@ func resourcePwpushPushDelete(ctx context.Context, d *schema.ResourceData, m int
 		// Read body just in case
 		body, _ := io.ReadAll(resp.Body)
 		if strings.Contains(string(body), "already expired") {
-			// Treat as success
 			d.SetId("")
 			return nil
 		}

--- a/internal/resource_push.go
+++ b/internal/resource_push.go
@@ -204,6 +204,17 @@ func resourcePwpushPushDelete(ctx context.Context, d *schema.ResourceData, m int
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == 404 || resp.StatusCode == 422 {
+		// Read body just in case
+		body, _ := io.ReadAll(resp.Body)
+		if strings.Contains(string(body), "already expired") {
+			// Treat as success
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("failed to delete push: %d - %s", resp.StatusCode, body)
+	}
+
 	if resp.StatusCode != 200 && resp.StatusCode != 204 {
 		body, _ := io.ReadAll(resp.Body)
 		return diag.Errorf("failed to delete push: %d - %s", resp.StatusCode, body)


### PR DESCRIPTION
Hi

I just found that the endpoint of Password Pusher cannot be overrided by the env var PWPUSH_ENDPOINT, because of **DefaultFunc** being ignored as long as the **Default** is provided, so it is only set to the Default value.


I also included a fix for the behaviour when a link in Password Pusher is expired, and because of that terraform cannot delete it.

```
Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

pwpush_push.this: Destroying... [id=3nlludemd6uvka]
╷
│ Error: failed to delete push: 422 - {"error":"That push is already expired."}
│
│
```